### PR TITLE
Update hipchat.py

### DIFF
--- a/graphite_beacon/handlers/hipchat.py
+++ b/graphite_beacon/handlers/hipchat.py
@@ -40,5 +40,5 @@ class HipChatHandler(AbstractHandler):
         }
 
         yield self.client.fetch('{url}/v2/room/{room}/notification?auth_token={token}'.format(
-            url=self.options.url, room=self.room, token=self.key),
+            url=self.options.get('url'), room=self.room, token=self.key),
             headers={'Content-Type': 'application/json'}, method='POST', body=json.dumps(data))


### PR DESCRIPTION
Currently hipchat support does not work because options is accessed as an object instead of as a dictionary in this one location. This change should fix the problem.
